### PR TITLE
Add effective field calculation to MacEq

### DIFF
--- a/SpinWaveToolkit/core/_class_MacrospinEquilibrium.py
+++ b/SpinWaveToolkit/core/_class_MacrospinEquilibrium.py
@@ -108,6 +108,8 @@ class MacrospinEquilibrium:
     recalc_params
     minimize
     eval_energy
+    getHeff
+    hysteresis
 
     Examples
     --------

--- a/docs/source/_example_nbs/macrospin_equilibrium_histloop.ipynb
+++ b/docs/source/_example_nbs/macrospin_equilibrium_histloop.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Static magnetization equilibrium and hysteresis loops\n",
-    "In this example, we show how to use our `MacrospinEquilibrium` class to calculate static direction of magnetization in simple systems. The output can then be used in `SingleLayerNumeric` *(other classes don't work for partially OOP magnetization, yet)*. Eventually, it can also be used to calculate hysteresis loops or field-swept ferromagnetic resonance frequencies (`### make an example on the FMR sweep and reference it here`).\n",
+    "In this example, we show how to use our `MacrospinEquilibrium` class to calculate static direction of magnetization in simple systems. The output can then be used in `SingleLayerNumeric` *(other classes don't work for partially OOP magnetization, yet)*. Eventually, it can also be used to calculate hysteresis loops or field-swept ferromagnetic resonance frequencies in films with some uniaxial anisotropies (`### make an example on the FMR sweep and reference it here`).\n",
     "\n",
     "*Note: It is based on a single macrospin model, so do not expect it to be super exact for thick films, waveguides, etc.*\n",
     "\n",
@@ -116,6 +116,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "70ea9af2",
+   "metadata": {},
+   "source": [
+    "## Calculation of effective field\n",
+    "It's also possible to calculate the effective field $\\mu_0H_{\\mathrm{eff}}$ (here denoted as `Heff`). To do this, use the `maceq.getHeff()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c3704b36",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "theta = 1.281 rad, phi = 0.000 rad, Heff = 0.335 T\n"
+     ]
+    }
+   ],
+   "source": [
+    "Heff_data = maceq.getHeff()\n",
+    "print(\"theta = {:.3f} rad, phi = {:.3f} rad, Heff = {:.3f} T\".format(*Heff_data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55ab43b5",
+   "metadata": {},
+   "source": [
+    "The resulting direction angles of Heff are the same as for M, which complies with the condition of equilibrium (effective field parallel to static magnetization). However, this method can be called at any time, even before the system is minimized. For example, by setting the magnetization angles to some non-equilibrium value, one can explore the direction and magnitude of the effective field."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "67d4af92",
    "metadata": {},
    "source": [
@@ -125,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "137d7121",
    "metadata": {},
    "outputs": [],
@@ -149,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c8688d61",
    "metadata": {},
    "outputs": [
@@ -164,7 +200,7 @@
        "        [-1.21817870e-18, -0.00000000e+00, -7.45919322e-35]])}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "3595afa8",
    "metadata": {},
    "outputs": [
@@ -206,13 +242,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[####################] 100.0 % | elapsed:   5.6 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   4.2 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   3.7 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   3.5 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   3.9 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   4.0 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   4.4 s | ETC:   0.0 s\n"
+      "[####################] 100.0 % | 00:02.0<00:00.0\n",
+      "[####################] 100.0 % | 00:01.6<00:00.0\n",
+      "[####################] 100.0 % | 00:01.7<00:00.0\n",
+      "[####################] 100.0 % | 00:01.7<00:00.0\n",
+      "[####################] 100.0 % | 00:01.8<00:00.0\n",
+      "[####################] 100.0 % | 00:01.9<00:00.0\n",
+      "[####################] 100.0 % | 00:01.8<00:00.0\n"
      ]
     },
     {
@@ -274,7 +310,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": ".venv (3.13.5)",
    "language": "python",
    "name": "python3"
   },
@@ -288,7 +324,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/examples/macrospin_equilibrium_histloop.ipynb
+++ b/examples/macrospin_equilibrium_histloop.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Static magnetization equilibrium and hysteresis loops\n",
-    "In this example, we show how to use our `MacrospinEquilibrium` class to calculate static direction of magnetization in simple systems. The output can then be used in `SingleLayerNumeric` *(other classes don't work for partially OOP magnetization, yet)*. Eventually, it can also be used to calculate hysteresis loops or field-swept ferromagnetic resonance frequencies (`### make an example on the FMR sweep and reference it here`).\n",
+    "In this example, we show how to use our `MacrospinEquilibrium` class to calculate static direction of magnetization in simple systems. The output can then be used in `SingleLayerNumeric` *(other classes don't work for partially OOP magnetization, yet)*. Eventually, it can also be used to calculate hysteresis loops or field-swept ferromagnetic resonance frequencies in films with some uniaxial anisotropies (`### make an example on the FMR sweep and reference it here`).\n",
     "\n",
     "*Note: It is based on a single macrospin model, so do not expect it to be super exact for thick films, waveguides, etc.*\n",
     "\n",
@@ -116,6 +116,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "70ea9af2",
+   "metadata": {},
+   "source": [
+    "## Calculation of effective field\n",
+    "It's also possible to calculate the effective field $\\mu_0H_{\\mathrm{eff}}$ (here denoted as `Heff`). To do this, use the `maceq.getHeff()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c3704b36",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "theta = 1.281 rad, phi = 0.000 rad, Heff = 0.335 T\n"
+     ]
+    }
+   ],
+   "source": [
+    "Heff_data = maceq.getHeff()\n",
+    "print(\"theta = {:.3f} rad, phi = {:.3f} rad, Heff = {:.3f} T\".format(*Heff_data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55ab43b5",
+   "metadata": {},
+   "source": [
+    "The resulting direction angles of Heff are the same as for M, which complies with the condition of equilibrium (effective field parallel to static magnetization). However, this method can be called at any time, even before the system is minimized. For example, by setting the magnetization angles to some non-equilibrium value, one can explore the direction and magnitude of the effective field."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "67d4af92",
    "metadata": {},
    "source": [
@@ -125,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "137d7121",
    "metadata": {},
    "outputs": [],
@@ -149,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c8688d61",
    "metadata": {},
    "outputs": [
@@ -164,7 +200,7 @@
        "        [-1.21817870e-18, -0.00000000e+00, -7.45919322e-35]])}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "3595afa8",
    "metadata": {},
    "outputs": [
@@ -206,13 +242,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[####################] 100.0 % | elapsed:   5.6 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   4.2 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   3.7 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   3.5 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   3.9 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   4.0 s | ETC:   0.0 s\n",
-      "[####################] 100.0 % | elapsed:   4.4 s | ETC:   0.0 s\n"
+      "[####################] 100.0 % | 00:02.0<00:00.0\n",
+      "[####################] 100.0 % | 00:01.6<00:00.0\n",
+      "[####################] 100.0 % | 00:01.7<00:00.0\n",
+      "[####################] 100.0 % | 00:01.7<00:00.0\n",
+      "[####################] 100.0 % | 00:01.8<00:00.0\n",
+      "[####################] 100.0 % | 00:01.9<00:00.0\n",
+      "[####################] 100.0 % | 00:01.8<00:00.0\n"
      ]
     },
     {
@@ -274,7 +310,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": ".venv (3.13.5)",
    "language": "python",
    "name": "python3"
   },
@@ -288,7 +324,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adds a method to the MacrospinEquilibrium class which numerically calculates the direction and magnitude of the effective field.

The related example was updated accordingly (also in docs).

Solves: #40 