### PR TITLE
Fix simpson() calls for SciPy >= 1.14 compatibility

### DIFF
--- a/SpinWaveToolkit/bls/core/_class_ObjectiveLens.py
+++ b/SpinWaveToolkit/bls/core/_class_ObjectiveLens.py
@@ -129,7 +129,7 @@ class ObjectiveLens:
                 * (1 + np.cos(theta))
                 * jv(0, k0 * rhoi * np.sin(theta))
                 * np.exp(1j * k0 * z * np.cos(theta)),
-                theta,
+                x=theta,
             )
             I01[i] = simpson(
                 fw
@@ -137,7 +137,7 @@ class ObjectiveLens:
                 * (np.sin(theta) ** 2)
                 * jv(1, k0 * rhoi * np.sin(theta))
                 * np.exp(1j * k0 * z * np.cos(theta)),
-                theta,
+                x=theta,
             )
             I02[i] = simpson(
                 fw
@@ -146,7 +146,7 @@ class ObjectiveLens:
                 * (1 - np.cos(theta))
                 * jv(2, k0 * rhoi * np.sin(theta))
                 * np.exp(1j * k0 * z * np.cos(theta)),
-                theta,
+                x=theta,
             )
             for j, phii in enumerate(phi):
                 common_factor = (
@@ -225,7 +225,7 @@ class ObjectiveLens:
                 * jv(1, k0 * rhoi * np.sin(theta))
                 * np.exp(1j * k0 * z * np.cos(theta))
             )
-            Irad[i] = simpson(integrand_rad, theta)
+            Irad[i] = simpson(integrand_rad, x=theta)
 
             integrand_I10 = (
                 fw
@@ -234,7 +234,7 @@ class ObjectiveLens:
                 * jv(0, k0 * rhoi * np.sin(theta))
                 * np.exp(1j * k0 * z * np.cos(theta))
             )
-            I10[i] = simpson(integrand_I10, theta)
+            I10[i] = simpson(integrand_I10, x=theta)
 
             for j, phii in enumerate(phi):
                 common_factor = (
@@ -312,7 +312,7 @@ class ObjectiveLens:
                 * jv(1, k0 * rhoi * np.sin(theta))
                 * np.exp(1j * k0 * z * np.cos(theta))
             )
-            Iazm[i] = simpson(integrand_azm, theta)
+            Iazm[i] = simpson(integrand_azm, x=theta)
             for j, phii in enumerate(phi):
                 common_factor = (
                     1j


### PR DESCRIPTION
## Summary
SciPy 1.14 made the `x` argument of `scipy.integrate.simpson` keyword-only. The BLS submodule still passed the integration coordinate positionally, so with SciPy >= 1.14 the focal-field methods raised:

```
TypeError: simpson() takes 1 positional argument but 2 were given
```

This PR changes all six `simpson(y, theta)` calls in `SpinWaveToolkit/bls/core/_class_ObjectiveLens.py` (in `getFocalField`, `getFocalFieldRad`, and `getFocalFieldAzm`) to `simpson(y, x=theta)`. This syntax is also fully backward compatible with older SciPy versions. A search over the whole package confirmed these are the only `simpson(` call sites.

## Testing
- `pytest tests` passes (4 passed) with SciPy 1.17.1 / NumPy 2.4.2.
- All three methods (`getFocalField`, `getFocalFieldRad`, `getFocalFieldAzm`) were exercised directly under SciPy 1.17.1 and return finite fields with the expected shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)